### PR TITLE
Add initial constrained delaunay triangulation

### DIFF
--- a/example/globe.js
+++ b/example/globe.js
@@ -57,6 +57,16 @@ new GeoJSONLoader()
 	.loadAsync( url )
 	.then( res => {
 
+		const queryParams = new URLSearchParams( location.search );
+		const country = queryParams.get( 'country' ) || 'Japan';
+		let thickness = parseFloat( queryParams.get( 'thickness' ) );
+		let resolution = parseFloat( queryParams.get( 'resolution' ) ) || 5;
+		if ( thickness !== 0 ) {
+
+			thickness = thickness || ( 1e5 * 0.5 );
+
+		}
+
 		// add base globe color
 		const globeBase = new Mesh(
 			new SphereGeometry( 1, 100, 50 ),
@@ -79,19 +89,21 @@ new GeoJSONLoader()
 
 			const line = geom.getLineObject( {
 				ellipsoid: WGS84_ELLIPSOID,
+				resolution,
 			} );
 			group.add( line );
 
 		} );
 
 		res.features
-			.filter( f => /Japan/.test( f.properties.name ) )
+			.filter( f => new RegExp( country ).test( f.properties.name ) )
 			.flatMap( f => f.polygons )
 			.forEach( geom => {
 
 				const mesh = geom.getMeshObject( {
-					thickness: 1e5,
 					ellipsoid: WGS84_ELLIPSOID,
+					thickness,
+					resolution,
 				} );
 				mesh.material = new MeshStandardMaterial();
 				group.add( mesh );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
+        "@kninnug/constrainautor": "^4.0.0",
         "@turf/unkink-polygon": "^7.2.0",
-        "betterknown": "^1.0.5"
+        "betterknown": "^1.0.5",
+        "delaunator": "^5.0.1"
       },
       "devDependencies": {
         "3d-tiles-renderer": "^0.4.9",
@@ -527,6 +529,14 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
+    },
+    "node_modules/@kninnug/constrainautor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@kninnug/constrainautor/-/constrainautor-4.0.0.tgz",
+      "integrity": "sha512-tIlqPYscvULOA4jkAYxczIXm8bX7t9h2cvnE0p5KYHVQai58XkjoxCWRDhdmEEub/pLurFKdhWmuJrOxKD1qzw==",
+      "dependencies": {
+        "robust-predicates": "^3.0.1"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1243,6 +1253,14 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/doctrine": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
   "author": "Garrett Johnson <garrett.kjohnson@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "@kninnug/constrainautor": "^4.0.0",
     "@turf/unkink-polygon": "^7.2.0",
-    "betterknown": "^1.0.5"
+    "betterknown": "^1.0.5",
+    "delaunator": "^5.0.1"
   },
   "devDependencies": {
     "3d-tiles-renderer": "^0.4.9",

--- a/src/GeoJSONShapeUtils.js
+++ b/src/GeoJSONShapeUtils.js
@@ -116,6 +116,8 @@ export function resampleLine( loop, minDistance ) {
 
 	}
 
+	result.push( loop[ loop.length - 1 ] );
+
 	return result;
 
 }

--- a/src/GeoJSONShapeUtils.js
+++ b/src/GeoJSONShapeUtils.js
@@ -90,6 +90,7 @@ export function traverse( object, callback ) {
 
 }
 
+// takes the provided line and resamples it so the segments are at most minDistance long
 export function resampleLine( loop, minDistance ) {
 
 	const result = [];
@@ -116,5 +117,61 @@ export function resampleLine( loop, minDistance ) {
 	}
 
 	return result;
+
+}
+
+// calculates the area of the given loop
+export function calculateArea( loop ) {
+
+	const n = loop.length;
+	let a = 0.0;
+
+	for ( let p = n - 1, q = 0; q < n; p = q ++ ) {
+
+		a += loop[ p ][ 0 ] * loop[ q ][ 1 ] - loop[ q ][ 0 ] * loop[ p ][ 1 ];
+
+	}
+
+	return a * 0.5;
+
+}
+
+// returns whether the given loop is clockwise or not
+export function isClockWise( loop ) {
+
+	return calculateArea( loop ) < 0;
+
+}
+
+// returns the angle sum of all the segments relative to the given point
+export function calculateAngleSum( loop, x, y ) {
+
+	let angleSum = 0;
+	for ( let i = 0, l = loop.length; i < l; i ++ ) {
+
+		const ni = ( i + 1 ) % l;
+
+		const c0 = loop[ i ];
+		const c1 = loop[ ni ];
+
+		let dx0 = c0[ 0 ] - x;
+		let dy0 = c0[ 1 ] - y;
+		let dx1 = c1[ 0 ] - x;
+		let dy1 = c1[ 1 ] - y;
+
+		const l0 = Math.sqrt( dx0 ** 2 + dy0 ** 2 );
+		const l1 = Math.sqrt( dx1 ** 2 + dy1 ** 2 );
+
+		dx0 /= l0;
+		dy0 /= l0;
+
+		dx1 /= l1;
+		dy1 /= l1;
+
+		angleSum += Math.atan2( dx0 * dy1 - dy0 * dx1, dx0 * dx1 + dy0 * dy1 );
+
+	}
+
+	return Math.abs( angleSum );
 
 }

--- a/src/PolygonUtils.js
+++ b/src/PolygonUtils.js
@@ -96,24 +96,11 @@ export function correctPolygonWinding( polygon ) {
 
 }
 
-export function dedupePolygonPoints( polygons ) {
+export function dedupePolygonPoints( polygon ) {
 
-	// clone each polygon with deduped set of vertices
-	const result = polygons
-		.map( polygon => {
-
-			return polygon
-				.map( loop => dedupeCoordinates( loop.slice() ) )
-				.filter( loop => loop.length > 3 );
-
-		} )
-		.filter( polygon => {
-
-			return polygon.length !== 0;
-
-		} );
-
-	return result;
+	return polygon
+		.map( loop => dedupeCoordinates( loop.slice() ) )
+		.filter( loop => loop.length > 3 );
 
 }
 

--- a/src/PolygonUtils.js
+++ b/src/PolygonUtils.js
@@ -1,0 +1,134 @@
+import { Vector3 } from 'three';
+import { unkinkPolygon } from '@turf/unkink-polygon';
+import { dedupeCoordinates, isClockWise } from './GeoJSONShapeUtils.js';
+
+const _min = new /* @__PURE__ */ Vector3();
+const _max = new /* @__PURE__ */ Vector3();
+const _center = new /* @__PURE__ */ Vector3();
+
+export function splitPolygon( polygon ) {
+
+	// get the dimension of the loops
+	const dimension = polygon[ 0 ][ 0 ].length;
+
+	// find the bounds of the shape
+	getPolygonBounds( polygon, _min, _max );
+	_center.addVectors( _min, _max ).multiplyScalar( 0.5 );
+
+	// offset the shape to near zero to improve precision
+	polygon.forEach( loop => loop.forEach( coord => {
+
+		coord[ 0 ] -= _center.x;
+		coord[ 1 ] -= _center.y;
+
+	} ) );
+
+	// unkink the polygon
+	const fixedPolygons = unkinkPolygon( { type: 'Polygon', coordinates: polygon } )
+		.features.map( feature => feature.geometry.coordinates );
+
+	// Reset the centering
+	fixedPolygons.forEach( shape => shape.forEach( loop => loop.forEach( coord => {
+
+		coord[ 0 ] += _center.x;
+		coord[ 1 ] += _center.y;
+
+	} ) ) );
+
+	// Fix the 2d offset
+	if ( fixedPolygons.length > 1 && dimension > 2 ) {
+
+		fixedPolygons.forEach( shape => shape.forEach( loop => loop.forEach( coord => {
+
+			if ( coord.length === 2 ) {
+
+				coord[ 2 ] = _center.z;
+
+			}
+
+		} ) ) );
+
+	}
+
+	return fixedPolygons;
+
+}
+
+export function getPolygonBounds( polygon, min, max ) {
+
+	min.setScalar( Infinity );
+	max.setScalar( - Infinity );
+	polygon.forEach( loop => loop.forEach( coord => {
+
+		const [ x, y, z = 0 ] = coord;
+		min.x = Math.min( min.x, x );
+		min.y = Math.min( min.y, y );
+		min.z = Math.min( min.z, z );
+
+		max.x = Math.max( max.x, x );
+		max.y = Math.max( max.y, y );
+		max.z = Math.max( max.z, z );
+
+	} ) );
+
+}
+
+export function cleanPolygons( polygons ) {
+
+	// clone each polygon with deduped set of vertices
+	const result = polygons
+		.map( polygon => {
+
+			return polygon
+				.map( loop => dedupeCoordinates( loop.slice() ) )
+				.filter( loop => loop.length > 3 );
+
+		} )
+		.map( polygon => {
+
+			const [ contour, ...holes ] = polygon;
+			if ( ! isClockWise( contour ) ) {
+
+				contour.reverse();
+
+			}
+
+			holes.forEach( hole => {
+
+				if ( isClockWise( hole ) ) {
+
+					hole.reverse();
+
+				}
+
+			} );
+
+			return polygon;
+
+		} )
+		.filter( polygon => {
+
+			return polygon.length !== 0;
+
+		} );
+
+	return result;
+
+}
+
+export function countVerticesInPolygons( polygons ) {
+
+	let total = 0;
+	polygons.forEach( polygon => {
+
+		polygon.forEach( loop => {
+
+			total += loop.length;
+
+		} );
+
+	} );
+
+	return total;
+
+}

--- a/src/PolygonUtils.js
+++ b/src/PolygonUtils.js
@@ -73,7 +73,30 @@ export function getPolygonBounds( polygon, min, max ) {
 
 }
 
-export function cleanPolygons( polygons ) {
+export function correctPolygonWinding( polygon ) {
+
+	const [ contour, ...holes ] = polygon;
+	if ( ! isClockWise( contour ) ) {
+
+		contour.reverse();
+
+	}
+
+	holes.forEach( hole => {
+
+		if ( isClockWise( hole ) ) {
+
+			hole.reverse();
+
+		}
+
+	} );
+
+	return polygon;
+
+}
+
+export function dedupePolygonPoints( polygons ) {
 
 	// clone each polygon with deduped set of vertices
 	const result = polygons
@@ -82,28 +105,6 @@ export function cleanPolygons( polygons ) {
 			return polygon
 				.map( loop => dedupeCoordinates( loop.slice() ) )
 				.filter( loop => loop.length > 3 );
-
-		} )
-		.map( polygon => {
-
-			const [ contour, ...holes ] = polygon;
-			if ( ! isClockWise( contour ) ) {
-
-				contour.reverse();
-
-			}
-
-			holes.forEach( hole => {
-
-				if ( isClockWise( hole ) ) {
-
-					hole.reverse();
-
-				}
-
-			} );
-
-			return polygon;
 
 		} )
 		.filter( polygon => {

--- a/src/constructPolygonMeshObject.js
+++ b/src/constructPolygonMeshObject.js
@@ -2,6 +2,7 @@ import { Vector3, ShapeUtils, BufferAttribute, Mesh } from 'three';
 import { unkinkPolygon } from '@turf/unkink-polygon';
 import { dedupeCoordinates } from './GeoJSONShapeUtils.js';
 import { getCenter, offsetPoints, transformToEllipsoid } from './FlatVertexBufferUtils.js';
+import { triangulate } from './triangulate.js';
 
 const _vec = new /* @__PURE__ */ Vector3();
 const _min = new /* @__PURE__ */ Vector3();
@@ -159,6 +160,8 @@ export function constructPolygonMeshObject( polygons, options = {} ) {
 
 	} );
 
+	// vectorPolygons.splice( 0, Infinity );
+
 	// construct the list of positions
 	let index = 0;
 	const halfOffset = totalVerts / 2;
@@ -199,7 +202,10 @@ export function constructPolygonMeshObject( polygons, options = {} ) {
 	vectorPolygons.forEach( polygon => {
 
 		const [ contour, ...holes ] = polygon;
-		const indices = ShapeUtils.triangulateShape( contour, holes ).flatMap( f => f );
+
+		let indices = ShapeUtils.triangulateShape( contour, holes ).flatMap( f => f );
+		const indices2 = Array.from( triangulate( contour, holes ) );
+		indices = indices2.reverse();
 
 		let totalVerts = contour.length;
 		holes.forEach( hole => totalVerts += hole.length );

--- a/src/constructPolygonMeshObject.js
+++ b/src/constructPolygonMeshObject.js
@@ -71,7 +71,9 @@ export function constructPolygonMeshObject( polygons, options = {} ) {
 
 	// clean up, filter, and ensure winding order of the polygon shapes,
 	// then split the polygon into separate components
-	let cleanedPolygons = dedupePolygonPoints( polygons )
+	let cleanedPolygons = polygons
+		.map( polygon => dedupePolygonPoints( polygon ) )
+		.filter( polygon => polygon.length !== 0 )
 		.flatMap( polygon => splitPolygon( polygon ) )
 		.map( polygon => correctPolygonWinding( polygon ) );
 

--- a/src/constructPolygonMeshObject.js
+++ b/src/constructPolygonMeshObject.js
@@ -1,5 +1,5 @@
 import { BufferAttribute, Mesh, Vector3 } from 'three';
-import { cleanPolygons, getPolygonBounds, splitPolygon } from './PolygonUtils.js';
+import { correctPolygonWinding, dedupePolygonPoints, getPolygonBounds, splitPolygon } from './PolygonUtils.js';
 import { calculateAngleSum, resampleLine } from './GeoJSONShapeUtils.js';
 import { triangulate } from './triangulate.js';
 import { getCenter, offsetPoints, transformToEllipsoid } from './FlatVertexBufferUtils.js';
@@ -71,8 +71,9 @@ export function constructPolygonMeshObject( polygons, options = {} ) {
 
 	// clean up, filter, and ensure winding order of the polygon shapes,
 	// then split the polygon into separate components
-	const cleanedPolygons = cleanPolygons( polygons )
-		.flatMap( polygon => splitPolygon( polygon ) );
+	let cleanedPolygons = dedupePolygonPoints( polygons )
+		.flatMap( polygon => splitPolygon( polygon ) )
+		.map( polygon => correctPolygonWinding( polygon ) );
 
 	const triangulations = cleanedPolygons.map( polygon => {
 

--- a/src/constructPolygonMeshObject.js
+++ b/src/constructPolygonMeshObject.js
@@ -10,7 +10,7 @@ const _max = new /* @__PURE__ */ Vector3();
 
 function pointIsInPolygon( polygon, x, y ) {
 
-	// TODO: check distnce to edges
+	// TODO: check distance to edges
 
 	const [ contour, ...holes ] = polygon;
 	const isInContour = calculateAngleSum( contour, x, y ) > 3.14;
@@ -39,10 +39,14 @@ function getInnerPoints( polygon, resolution ) {
 
 	getPolygonBounds( polygon, _min, _max );
 
-	const result = [];
-	for ( let x = _min.x, lx = _max.x; x < lx; x += resolution ) {
+	// align all points to a common grid so other polygons will line up
+	const startX = Math.sign( _min.x ) * Math.ceil( Math.abs( _min.x / resolution ) ) * resolution;
+	const startY = Math.sign( _min.y ) * Math.ceil( Math.abs( _min.y / resolution ) ) * resolution;
 
-		for ( let y = _min.y, ly = _max.y; y < ly; y += resolution ) {
+	const result = [];
+	for ( let x = startX, lx = _max.x; x < lx; x += resolution ) {
+
+		for ( let y = startY, ly = _max.y; y < ly; y += resolution ) {
 
 			if ( pointIsInPolygon( polygon, x, y ) ) {
 

--- a/src/triangulate.js
+++ b/src/triangulate.js
@@ -1,0 +1,147 @@
+import Delaunator from 'delaunator';
+import Constrainautor from '@kninnug/constrainautor';
+
+function getLoopEdges( loop, offset, target = [] ) {
+
+	loop.forEach( ( e, i ) => {
+
+		const e0 = i + offset;
+		const e1 = ( i + 1 ) % loop.length + offset;
+
+		target.push( [
+			e0,
+			e1,
+		] );
+
+	} );
+
+	return target;
+
+}
+
+// find the triangle index with the provided edge
+function findTriangleWithEdge( triangles, edge ) {
+
+	const [ e0, e1 ] = edge;
+	for ( let i = 0, l = triangles.length; i < l; i += 3 ) {
+
+		for ( let j = 0; j < 3; j ++ ) {
+
+			const n = ( j + 1 ) % 3;
+			const t0 = triangles[ i + j ];
+			const t1 = triangles[ i + n ];
+
+			if ( t0 === e0 && t1 === e1 ) {
+
+				return i / 3;
+
+			}
+
+		}
+
+	}
+
+	return - 1;
+
+}
+
+export function triangulate( contour, holes ) {
+
+	let offset = 0;
+	const constrainedIndices = [];
+	getLoopEdges( contour, offset, constrainedIndices );
+	offset += contour.length;
+
+	holes.forEach( hole => {
+
+		getLoopEdges( hole, offset, constrainedIndices );
+		offset += hole.length;
+
+	} );
+
+
+	const points = [ ...contour, ...holes.flatMap( hole => hole ) ].map( coord => [ coord.x, coord.y ] );
+	const delaunay = Delaunator.from( points );
+	const con = new Constrainautor( delaunay );
+	con.constrainAll( constrainedIndices );
+
+	const result = [];
+	const { triangles, halfedges } = delaunay;
+	const startTri = findTriangleWithEdge( triangles, constrainedIndices[ 0 ] );
+
+	if ( startTri === - 1 ) {
+
+		throw new Error();
+
+	}
+
+	const edgeHashSet = new Set();
+	constrainedIndices.forEach( ( [ e0, e1 ] ) => {
+
+		edgeHashSet.add( `${ e0 }_${ e1 }` );
+
+	} );
+
+	const traversed = new Set();
+	const stack = [ startTri ];
+	while ( stack.length > 0 ) {
+
+		const tri = stack.pop();
+		if ( traversed.has( tri ) ) {
+
+			continue;
+
+		}
+
+		traversed.add( tri );
+
+		const tri3 = 3 * tri;
+		for ( let v = 0; v < 3; v ++ ) {
+
+			// add this triangle to the list of results
+			result.push( triangles[ tri3 + v ] );
+
+			// calculate the next half edge index
+			const siblingEdge = halfedges[ tri3 + v ];
+			if ( siblingEdge === - 1 ) {
+
+				continue;
+
+			}
+
+			// calculate the other tri index
+			const otherTri = ~ ~ ( siblingEdge / 3 );
+			if ( traversed.has( otherTri ) ) {
+
+				continue;
+
+			}
+
+			const p0 = siblingEdge - ( otherTri * 3 );
+			const p1 = ( p0 + 1 ) % 3;
+			const e0 = triangles[ otherTri * 3 + p0 ];
+			const e1 = triangles[ otherTri * 3 + p1 ];
+			const found = edgeHashSet.has( `${ e1 }_${ e0 }` );
+
+			if ( ! found ) {
+
+				stack.push( otherTri );
+
+			}
+
+		}
+
+	}
+
+	return result;
+
+
+	return [
+		triangles[ startTri * 3 + 0 ],
+		triangles[ startTri * 3 + 1 ],
+		triangles[ startTri * 3 + 2 ],
+	];
+
+	return delaunay.triangles;
+
+}


### PR DESCRIPTION
Related to #3, #2, #5

**TODO**
- Add option / auto fallback to earcut for speed if needed
- Performance improvement
  - need to check performance before and after culling points outside the polygons

**Performance Bottlenecks**
- Unkink polygon
- Point in polygon checks

**Next**
- Ellipsoid-spaced points
- Avoid points near edges (see if this causes issues ever)
- Smooth normals
- Performance fixes
  - Avoid point in polygon checks, resample positions, indices, edges - generate unmerged geometry instead? Would allow for fast normal generation