### PR TITLE
Remove pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ Definition of a parsed set of polygon geometry. `Ellipsoid` is from the 3d-tiles
   getMeshObject( options: {
     thickness = 0: number,
     offset = 0: number,
-    generateNormals = true: boolean,
     flat = false: boolean,
 		ellipsoid = null: Ellipsoid,
 		resolution = null: number,

--- a/example/globe.js
+++ b/example/globe.js
@@ -87,18 +87,9 @@ new GeoJSONLoader()
 		// load the globe lines
 		res.polygons.forEach( geom => {
 
-			const line = geom.getLineObject( {
-				ellipsoid: WGS84_ELLIPSOID,
-				resolution,
-			} );
-			group.add( line );
+			const feature = geom.feature;
 
-		} );
-
-		res.features
-			.filter( f => new RegExp( country ).test( f.properties.name ) )
-			.flatMap( f => f.polygons )
-			.forEach( geom => {
+			if ( feature && new RegExp( country ).test( feature.properties.name ) ) {
 
 				const mesh = geom.getMeshObject( {
 					ellipsoid: WGS84_ELLIPSOID,
@@ -108,7 +99,17 @@ new GeoJSONLoader()
 				mesh.material = new MeshStandardMaterial();
 				group.add( mesh );
 
-			} );
+			} else {
+
+				const line = geom.getLineObject( {
+					ellipsoid: WGS84_ELLIPSOID,
+					resolution,
+				} );
+				group.add( line );
+
+			}
+
+		} );
 
 		// scale and center the model
 		const box = new Box3();

--- a/src/GeoJSONShapeUtils.js
+++ b/src/GeoJSONShapeUtils.js
@@ -177,3 +177,30 @@ export function calculateAngleSum( loop, x, y ) {
 	return Math.abs( angleSum );
 
 }
+
+export function isPointInPolygon( polygon, x, y ) {
+
+	// TODO: check distance to edges
+
+	const [ contour, ...holes ] = polygon;
+	const isInContour = calculateAngleSum( contour, x, y ) > 3.14;
+	if ( ! isInContour ) {
+
+		return false;
+
+	}
+
+	for ( let i = 0, l = holes.length; i < l; i ++ ) {
+
+		const isInHole = calculateAngleSum( holes[ i ], x, y ) > 3.14;
+		if ( isInHole ) {
+
+			return false;
+
+		}
+
+	}
+
+	return true;
+
+}

--- a/src/constructPolygonMeshObject.js
+++ b/src/constructPolygonMeshObject.js
@@ -51,13 +51,12 @@ export function constructPolygonMeshObject( polygons, options = {} ) {
 	const {
 		thickness = 0,
 		offset = 0,
-		generateNormals = true,
 		flat = false,
 		ellipsoid = null,
 		resolution = null,
 	} = options;
 
-	// clean up, filter, and ensure winding order of the polygon shapes,
+	// clone, clean up, filter, and ensure winding order of the polygon shapes,
 	// then split the polygon into separate components
 	let cleanedPolygons = polygons
 		.map( polygon => polygon.map( loop => loop.map( coord => coord.slice() ) ) )


### PR DESCRIPTION
Fix #19 
Fix #20 
Fix #18 

Brings time to triangulate the US down from ~100+ms to ~60ms. Remaining timing:

```
Clean loops: 14.1220703125 ms
Triangulate: 16.929931640625 ms
Build tri list: 2.656982421875 ms
Ellipsoid projection: 10.718994140625 ms
Offset points: 3.4990234375 ms
Create buffer attr: 3.5830078125 ms
Normal gen: 8.465087890625 ms
```

- Ellipsoid projection + offset points could be brought down by modifying and projecting the original loops so we don't have to duplicate the effort (relies on #18). 
- Creating buffer attributes can be brought down by pre-allocating the float 32 array and writing to it directly.
- Normal gen could come down with #20 and by calculating the normals ahead of time rather than using the calculate function