### PR TITLE
Fix invalid positions of @__PURE__ annotations

### DIFF
--- a/src/PolygonUtils.js
+++ b/src/PolygonUtils.js
@@ -2,9 +2,9 @@ import { Vector3 } from 'three';
 import { unkinkPolygon } from '@turf/unkink-polygon';
 import { dedupeCoordinates, isClockWise, isPointInPolygon } from './GeoJSONShapeUtils.js';
 
-const _min = new /* @__PURE__ */ Vector3();
-const _max = new /* @__PURE__ */ Vector3();
-const _center = new /* @__PURE__ */ Vector3();
+const _min = /* @__PURE__ */ new Vector3();
+const _max = /* @__PURE__ */ new Vector3();
+const _center = /* @__PURE__ */ new Vector3();
 
 function fixLoop( loop ) {
 

--- a/src/constructLineObject.js
+++ b/src/constructLineObject.js
@@ -2,7 +2,7 @@ import { BufferAttribute, LineSegments, Vector3 } from 'three';
 import { getCenter, offsetPoints, transformToEllipsoid } from './FlatVertexBufferUtils.js';
 import { resampleLine } from './GeoJSONShapeUtils.js';
 
-const _vec = new /* @__PURE__ */ Vector3();
+const _vec = /* @__PURE__ */ new Vector3();
 
 // Takes a set of vertex data and constructs a line segment
 export function constructLineObject( lineStrings, options = {} ) {

--- a/src/constructPolygonMeshObject.js
+++ b/src/constructPolygonMeshObject.js
@@ -4,11 +4,11 @@ import { resampleLine } from './GeoJSONShapeUtils.js';
 import { getLoopEdges, triangulate } from './triangulate.js';
 import { getCenter, offsetPoints, transformToEllipsoid } from './FlatVertexBufferUtils.js';
 
-const _vec = new /* @__PURE__ */ Vector3();
-const _dir1 = new /* @__PURE__ */ Vector3();
-const _dir2 = new /* @__PURE__ */ Vector3();
-const _min = new /* @__PURE__ */ Vector3();
-const _max = new /* @__PURE__ */ Vector3();
+const _vec = /* @__PURE__ */ new Vector3();
+const _dir1 = /* @__PURE__ */ new Vector3();
+const _dir2 = /* @__PURE__ */ new Vector3();
+const _min = /* @__PURE__ */ new Vector3();
+const _max = /* @__PURE__ */ new Vector3();
 
 // takes set of segment info from below and checks if a polygon lies on any of the segments
 function isPointOnPolygonEdge( segmentInfo, x, y ) {


### PR DESCRIPTION
because Rollup cannot interpret `@__PURE__` annotation in a invalid position.

# Before
We can see warnings from Rollup introduced by [this PR](https://github.com/rollup/rollup/pull/5165) while executing the build command.

```
$ npm run build-examples

> three-geojson@0.0.8 build-examples
> vite build --config ./vite.config.js

vite v6.3.5 building for production...
src/constructLineObject.js (5:17): A comment

"/* @__PURE__ */"

in "src/constructLineObject.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
src/constructPolygonMeshObject.js (7:17): A comment

"/* @__PURE__ */"

in "src/constructPolygonMeshObject.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
src/constructPolygonMeshObject.js (8:18): A comment

"/* @__PURE__ */"

in "src/constructPolygonMeshObject.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
src/constructPolygonMeshObject.js (9:18): A comment

"/* @__PURE__ */"

in "src/constructPolygonMeshObject.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
src/constructPolygonMeshObject.js (10:17): A comment

"/* @__PURE__ */"

in "src/constructPolygonMeshObject.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
src/constructPolygonMeshObject.js (11:17): A comment

"/* @__PURE__ */"

in "src/constructPolygonMeshObject.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
src/PolygonUtils.js (5:17): A comment

"/* @__PURE__ */"

in "src/PolygonUtils.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
src/PolygonUtils.js (6:17): A comment

"/* @__PURE__ */"

in "src/PolygonUtils.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
src/PolygonUtils.js (7:20): A comment

"/* @__PURE__ */"

in "src/PolygonUtils.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
✓ 84 modules transformed.
bundle/globe.html                            0.64 kB │ gzip:   0.39 kB
bundle/wkt.html                              0.65 kB │ gzip:   0.40 kB
bundle/extruded.html                         0.65 kB │ gzip:   0.40 kB
bundle/assets/world-EVCf79-S.geojson     4,388.82 kB
bundle/assets/extruded-D0fayBB6.js           1.25 kB │ gzip:   0.72 kB
bundle/assets/globe-CRItgO2d.js              5.47 kB │ gzip:   2.44 kB
bundle/assets/wkt-BV1jSwHs.js                8.78 kB │ gzip:   3.16 kB
bundle/assets/GeoJSONLoader-BOrNbtGm.js    548.50 kB │ gzip: 142.24 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 722ms
```

# After
We have no warnings about `@__PURE__`.

```
$ npm run build-examples

> three-geojson@0.0.8 build-examples
> vite build --config ./vite.config.js

vite v6.3.5 building for production...
✓ 84 modules transformed.
bundle/globe.html                            0.64 kB │ gzip:   0.39 kB
bundle/wkt.html                              0.65 kB │ gzip:   0.40 kB
bundle/extruded.html                         0.65 kB │ gzip:   0.40 kB
bundle/assets/world-EVCf79-S.geojson     4,388.82 kB
bundle/assets/extruded-D0fayBB6.js           1.25 kB │ gzip:   0.72 kB
bundle/assets/globe-CRItgO2d.js              5.47 kB │ gzip:   2.44 kB
bundle/assets/wkt-BV1jSwHs.js                8.78 kB │ gzip:   3.16 kB
bundle/assets/GeoJSONLoader-BOrNbtGm.js    548.50 kB │ gzip: 142.24 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 827ms
```